### PR TITLE
Change the way to render empty component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import {dissoc, has, includes, isNil, mergeRight, type} from "ramda";
+import {dissoc, has, includes, isEmpty, isNil, mergeRight, type} from "ramda";
 import ReactPropTypesSecret from "prop-types/lib/ReactPropTypesSecret";
 import PropTypes from "prop-types";
 import React from "react";
@@ -336,7 +336,7 @@ function resolveProps(props, functionalProps, context){
 
 function renderDashComponent(component, index=null) {
     // Nothing to render.
-    if (isNil(component)) {
+    if (isNil(component) || isEmpty(component)) {
         return null;
     }
     // Simple stuff such as strings.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import {dissoc, has, includes, isEmpty, mergeRight, type} from "ramda";
+import {dissoc, has, includes, isNil, mergeRight, type} from "ramda";
 import ReactPropTypesSecret from "prop-types/lib/ReactPropTypesSecret";
 import PropTypes from "prop-types";
 import React from "react";
@@ -336,7 +336,7 @@ function resolveProps(props, functionalProps, context){
 
 function renderDashComponent(component, index=null) {
     // Nothing to render.
-    if (isEmpty(component)) {
+    if (isNil(component)) {
         return null;
     }
     // Simple stuff such as strings.


### PR DESCRIPTION
Started facing an issue recently with null/undefined component props in dmc. Upon investigating, found this to be the issue. Although this fixes the issue, I did not investigate why it's become an issue only recently. Nevertheless, I think this should be the correct way to render "nothing".